### PR TITLE
Fix website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Numix Square
-Square is an icon theme for Linux from the [Numix project](http://numixproject.org). This readme provides information on [installation](https://github.com/numixproject/numix-icon-theme-square/#installation), [icon requests](https://github.com/numixproject/numix-icon-theme-square/#icon-requests) and [hardcoded icons](https://github.com/numixproject/numix-icon-theme-square/#hardcoded-icons). Licensed under the GPL-3.0+
+Square is an icon theme for Linux from the [Numix project](https://numixproject.github.io/). This readme provides information on [installation](https://github.com/numixproject/numix-icon-theme-square/#installation), [icon requests](https://github.com/numixproject/numix-icon-theme-square/#icon-requests) and [hardcoded icons](https://github.com/numixproject/numix-icon-theme-square/#hardcoded-icons). Licensed under the GPL-3.0+
 
 ## Install it
 If using this with our [base icon theme](https://github.com/numixproject/numix-icon-theme) make sure you install both parts using the same method. This makes sure that the panel icons keep working as intended.


### PR DESCRIPTION
I had been holding off on this, but from [this](https://plus.google.com/+NumixProjectOrg/posts/8x1DpFpVVV9) I assume http://numixproject.org/ isn't going to be alive anymore so this may as well be changed.
  