### PR TITLE
Fix Discord PTB symlink

### DIFF
--- a/Numix-Square/48/apps/discord-ptb.svg
+++ b/Numix-Square/48/apps/discord-ptb.svg
@@ -1,0 +1,1 @@
+discord.svg


### PR DESCRIPTION
Discord PTB has no special icon but most packages point it towards
a PTB icon. Simply symlink it to the default icon to resolve.